### PR TITLE
Validate email/name before using them

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -1,6 +1,14 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
 
+const emailErrorMessage =
+  "Unable to find author's email. Either ensure that the token's Github Account has the email " +
+  'privacy feature disabled for at least one email or use the `author-email` input to provide one.'
+
+const nameErrorMessage =
+  "Unable to find author's name. Either ensure that the token's Github Account has a valid name " +
+  'set in its profile or use the `author-name` input to provide one.'
+
 /**
  * Returns the login, email and name of the authenticated user using
  * the provided Github token.
@@ -20,7 +28,17 @@ export async function getAuthUser(token: string): Promise<AuthUser> {
     core.debug(`- Email: ${email}`)
     core.debug(`- Name: ${name}`)
 
-    return {login, email: () => email, name: () => name}
+    return {
+      login,
+      email: () => {
+        if (!email) throw new Error(emailErrorMessage)
+        return email
+      },
+      name: () => {
+        if (!name) throw new Error(nameErrorMessage)
+        return name
+      }
+    }
   } catch (error) {
     core.debug(error)
     throw new Error('Unable to retrieve user information from Github')

--- a/src/github.ts
+++ b/src/github.ts
@@ -20,7 +20,7 @@ export async function getAuthUser(token: string): Promise<AuthUser> {
     core.debug(`- Email: ${email}`)
     core.debug(`- Name: ${name}`)
 
-    return {login, email, name}
+    return {login, email: () => email, name: () => name}
   } catch (error) {
     core.debug(error)
     throw new Error('Unable to retrieve user information from Github')
@@ -28,7 +28,7 @@ export async function getAuthUser(token: string): Promise<AuthUser> {
 }
 
 interface AuthUser {
-  email: string
+  email: () => string
   login: string
-  name: string
+  name: () => string
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,8 +21,8 @@ async function run(): Promise<void> {
     const repo = check.reposFile() || check.githubRepository()
     const user = await github.getAuthUser(token)
 
-    const authorEmail = core.getInput('author-email') ?? user.email
-    const authorName = core.getInput('author-name') ?? user.name
+    const authorEmail = core.getInput('author-email') ?? user.email()
+    const authorName = core.getInput('author-name') ?? user.name()
 
     await files.prepareScalaStewardWorkspace(repo, token)
 


### PR DESCRIPTION
Just a small update to your changes in https://github.com/scala-steward-org/scala-steward-action/pull/38 to ensure email/name are "valid" before running Scala Steward.